### PR TITLE
PEP394 compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Currently it will output the results to `stdout` in CSV format
 
 ## Options
 ```
-$ python analyze-js.py -h
+$ ./analyze-js.py -h
 usage: analyze-js.py [-h] [-i file] [--csv] [--nocsv]
 
 Analyze ZAProxy JSON alert report

--- a/zapalyzer.py
+++ b/zapalyzer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 # MIT License
 # 


### PR DESCRIPTION
According to PEP394, script writers should expect that the `python` command may start Python 2.

Additionally, for scripts that may run in a virtual environment, the `python3` of the current environment should be used.

